### PR TITLE
fix: encoding overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.73"
+lazy_static = "1.4.0"
 num-traits = "0.2.14"
 starknet = "0.6.0"
 


### PR DESCRIPTION
This pull request closes #2 

The code relied on integers instead of FieldElements for handling domains ending with too many a, which could cause an overflow on the multiplication. Here is a fix.